### PR TITLE
Add /database/migrate to migrate the database after upgrade

### DIFF
--- a/lib/crowbar/init/application.rb
+++ b/lib/crowbar/init/application.rb
@@ -85,7 +85,9 @@ module Crowbar
               "-o '#{run_list}'"
             ].join(" ")
 
-            run_cmd(cmd)
+            return true if run_cmd(cmd)[:exit_code] == 0
+
+            false
           end
         end
 
@@ -388,7 +390,7 @@ module Crowbar
         }
 
         logger.debug("Creating Crowbar database")
-        if chef(attributes)[:exit_code] == 0
+        if chef(attributes)
           json(
             code: 200,
             body: nil
@@ -425,7 +427,7 @@ module Crowbar
         }
 
         logger.debug("Connecting Crowbar to external database")
-        if chef(attributes)[:exit_code] == 0
+        if chef(attributes)
           json(
             code: 200,
             body: nil


### PR DESCRIPTION
This PR is based on the assumption that `rake db:dump` is executed before the upgrade (should also work after the upgrade if we keep the sqllite gem).
