### PR TITLE
Set environment via RAILS_ENV

### DIFF
--- a/lib/crowbar/init/application.rb
+++ b/lib/crowbar/init/application.rb
@@ -30,6 +30,10 @@ module Crowbar
       set :assets_prefix, "/assets"
       set :digest_assets, false
 
+      if ENV["RAILS_ENV"] && !ENV["RACK_ENV"]
+        set :environment, ENV["RAILS_ENV"]
+      end
+
       before do
         logger.level = Logger::DEBUG
       end


### PR DESCRIPTION
Unless there is a RACK_ENV use the RAILS_ENV to set the environment.
This is required if we mount the app via rails.
