### PR TITLE
add an upgrade status endpoint

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -7,8 +7,12 @@ WORKERS = ENV["CROWBAR_INIT_WORKERS"] || 1
 LISTEN = ENV["CROWBAR_INIT_LISTEN"] || "127.0.0.1"
 PORT = ENV["CROWBAR_INIT_PORT"] || 4567
 
+CROWBAR_LIB_DIR = "/opt/dell/crowbar_framework/lib".freeze
+
 require "fileutils"
 require "rack/test"
+
+$LOAD_PATH.push CROWBAR_LIB_DIR if Dir.exist?(CROWBAR_LIB_DIR)
 
 directory ROOT
 environment ENVIRONMENT

--- a/lib/crowbar/init/application.rb
+++ b/lib/crowbar/init/application.rb
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+require "/opt/dell/crowbar_framework/lib/crowbar/upgrade_status"
+
 module Crowbar
   module Init
     #
@@ -284,6 +286,27 @@ module Crowbar
             }
           )
         end
+      end
+
+      # api :GET, "Crowbar upgrade status"
+      # api_version "2.0"
+      get "/api/upgrade" do
+        api_constraint(2.0)
+        http_code = 200
+        crowbar_upgrade_status = ::Crowbar::UpgradeStatus.new(logger)
+        if crowbar_upgrade_status.progress.is_a?(Hash)
+          response = crowbar_upgrade_status.progress
+        else
+          response = {
+            error: "Could not read from /var/lib/crowbar/upgrade/progress.yml"
+          }
+          http_code = 503
+        end
+
+        status http_code
+        json(
+          response
+        )
       end
 
       # api :POST, "Initialization during upgrade with creation of a new database"

--- a/lib/crowbar/init/application.rb
+++ b/lib/crowbar/init/application.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require "/opt/dell/crowbar_framework/lib/crowbar/upgrade_status"
+require "crowbar/upgrade_status"
 
 module Crowbar
   module Init


### PR DESCRIPTION
we are using the same url as in the crowbar api.
that makes it much easier for the clients to continue polling the
upgrade status during the upgrade

depends on https://github.com/crowbar/crowbar-core/pull/772