### PR TITLE
set the end_step after admin_upgrade

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -43,3 +43,11 @@ bind "tcp://#{LISTEN}:#{PORT}"
 ].each do |name|
   FileUtils.mkdir_p File.join(ROOT, name)
 end
+
+# set the end_step status during the upgrade
+if File.exist?("/var/lib/crowbar/upgrade/progress.yml")
+  require "logger"
+  require "crowbar/upgrade_status"
+  upgrade_status = ::Crowbar::UpgradeStatus.new(Logger.new(Logger::STDOUT))
+  upgrade_status.end_step if upgrade_status.current_step == :admin_upgrade
+end


### PR DESCRIPTION
unfortunately it is not possible to call this particular end_step
for the admin_upgrade just once from crowbar-init itself.
the only way this can be achieved is by placing it into the
'before' block, where it gets executed on every request which
is very expensive. only in this before block and within an api
endpoint block the logger is accessible.

as we don't want to require the user to call any endpoint to set
the end_step to the admin_upgrade, it should rather be done
automatically once by crowbar-init itself.

due to the restrictions of Sinatra, there was no simple way to just
require the upgrade_status library, pass the logger and call the
end_step under a condition.

so instead we use puma.rb to do that.
This should not be a big problem as in the normal case the server
just gets started once, and shuts itself down.