### PR TITLE
Parse JSON data in POST requests.

### DIFF
--- a/lib/crowbar/init/application.rb
+++ b/lib/crowbar/init/application.rb
@@ -31,6 +31,10 @@ module Crowbar
 
       before do
         logger.level = Logger::DEBUG
+        # parse JSON in POST requests
+        if request.request_method == "POST" && request.content_type.include?("json")
+          params.merge!(JSON.parse(request.body.read, symbolize_names: true))
+        end
       end
 
       configure do


### PR DESCRIPTION
Sinatra supports only application/x-www-form-urlencoded payloads in
POST request by default. The crowbar-ui sends requests in JSON format
which needs some additional preprocessing for proper handling.