### PR TITLE
[experimental] prolong crowbar-init's life for 10 more seconds

### DIFF
--- a/lib/crowbar/init/helpers.rb
+++ b/lib/crowbar/init/helpers.rb
@@ -129,7 +129,7 @@ module Crowbar
 
         Thread.new do
           # wait a bit to let the API request come back with 200
-          sleep 10
+          sleep 20
           cmd_ret = run_cmd(
             "sudo",
             "systemctl",


### PR DESCRIPTION
this is just an experiment to see how crowbar-init reacts to
psychological torture.

crowbarctl upgrade database new is running into a timeout, so it
may be the case that there is not enough time for the request
to come back with 200.