### PR TITLE
database: make postgresql adapter the default

### DIFF
--- a/chef/cookbooks/postgresql/templates/default/database.yml.erb
+++ b/chef/cookbooks/postgresql/templates/default/database.yml.erb
@@ -14,11 +14,14 @@
 # limitations under the License.
 #
 
+default: &default
+  adapter: postgresql
+  host: <%= @host %>
+  port: <%= @port %>
+  database: <%= @database %>
+  pool: 5
+  username: <%= @username %>
+  password: <%= @password %>
+
 production:
-   adapter: postgresql
-   host: <%= @host %>
-   port: <%= @port %>
-   database: <%= @database %>
-   pool: 5
-   username: <%= @username %>
-   password: <%= @password %>
+  <<: *default


### PR DESCRIPTION
this makes it easier to reuse this adapter for development by just
concatenating this to the template:

  development:
    <<: *default

from our automation to make sure to use the same database for a
development environment