### PR TITLE
run schema migrations only when crowbar is running

### DIFF
--- a/lib/crowbar/init/application.rb
+++ b/lib/crowbar/init/application.rb
@@ -101,7 +101,7 @@ module Crowbar
       # api_version "2.0"
       post "/api/migrate" do
         api_constraint(2.0)
-        if migrate_crowbar
+        if migrate_crowbar[:exit_code].zero?
           json(
             code: 200,
             body: nil
@@ -346,15 +346,6 @@ module Crowbar
             next
           end
 
-          res[:schema_migration] = {
-            success: migrate_crowbar
-          }
-          unless res[:schema_migration][:success]
-            http_code = 422
-            res[:error] = "Failed to migrate schemas"
-            next
-          end
-
           init = crowbar_init
           res[:crowbar_init] = {
             success: init[:code] == 200
@@ -426,15 +417,6 @@ module Crowbar
           unless res[:database_migration][:success]
             http_code = 422
             res[:error] = "Failed to migrate database"
-            next
-          end
-
-          res[:schema_migration] = {
-            success: migrate_crowbar
-          }
-          unless res[:schema_migration][:success]
-            http_code = 422
-            res[:error] = "Failed to migrate schemas"
             next
           end
 

--- a/lib/crowbar/init/helpers.rb
+++ b/lib/crowbar/init/helpers.rb
@@ -237,13 +237,11 @@ module Crowbar
       end
 
       def migrate_crowbar
-        cmd = run_cmd(
+        logger.debug("Migrating crowbar schemas")
+        run_cmd(
           "cd /opt/dell/crowbar_framework && " \
           "RAILS_ENV=production bin/rake crowbar:schema_migrate_prod"
         )
-        return true if cmd[:exit_code].zero?
-
-        false
       end
 
       def crowbar_init
@@ -257,6 +255,7 @@ module Crowbar
           [:symlink_apache_to, :rails],
           [:reload_apache],
           [:wait_for_crowbar],
+          [:migrate_crowbar],
           [:shutdown_crowbar_init]
         ].each do |command|
           cmd_ret = send(*command)


### PR DESCRIPTION
the schema migrations rely on the chef server, so we can't run them
at any time before crowbar is running