### PR TITLE
upgrade: don't lock the progress file when reading only the status

### DIFF
--- a/lib/crowbar/init/application.rb
+++ b/lib/crowbar/init/application.rb
@@ -293,7 +293,11 @@ module Crowbar
       get "/api/upgrade" do
         api_constraint(2.0)
         http_code = 200
-        crowbar_upgrade_status = ::Crowbar::UpgradeStatus.new(logger)
+        crowbar_upgrade_status = ::Crowbar::UpgradeStatus.new(
+          logger,
+          "/var/lib/crowbar/upgrade/6-to-7-progress.yml",
+          false
+        )
         if crowbar_upgrade_status.progress.is_a?(Hash)
           response = crowbar_upgrade_status.progress
         else


### PR DESCRIPTION
during the upgrade we will use a lot of polling to /api/upgrade
for the status, therefore we need as minimal impact/cost as
necessary

## Depends on
https://github.com/crowbar/crowbar-core/pull/919