### PR TITLE
Check content-type header exists before using it

### DIFF
--- a/lib/crowbar/init/application.rb
+++ b/lib/crowbar/init/application.rb
@@ -34,7 +34,8 @@ module Crowbar
       before do
         logger.level = Logger::DEBUG
         # parse JSON in POST requests
-        if request.request_method == "POST" && request.content_type.include?("json")
+        if request.request_method == "POST" &&
+            (!request.content_type.nil? && request.content_type.include?("json"))
           params.merge!(JSON.parse(request.body.read, symbolize_names: true))
         end
       end


### PR DESCRIPTION
If the Content-Type header includes 'json' we change our input to be 
parsed as JSON, but the client may not have sent such a header, so check
it is not nil first.