### PR TITLE
init: Switch to crowbar as last step

### DIFF
--- a/lib/crowbar/init/helpers.rb
+++ b/lib/crowbar/init/helpers.rb
@@ -272,12 +272,12 @@ module Crowbar
           [:crowbar_service, :start],
           [:crowbar_jobs_service, :enable],
           [:crowbar_jobs_service, :start],
-          [:symlink_apache_to, :rails],
-          [:reload_apache],
-          [:wait_for_crowbar],
           [:migrate_crowbar],
           [:update_config_db],
           [:seed_db],
+          [:symlink_apache_to, :rails],
+          [:reload_apache],
+          [:wait_for_crowbar],
           [:shutdown_crowbar_init]
         ].each do |command|
           cmd_ret = send(*command)


### PR DESCRIPTION
From a debugging POV it makes more sense to do the apache switch as last
step. If for e.g. the migrate_crowbar step failes and the config is
already changed then it's not possible to try the command again without
manual revertig the config change.