### PR TITLE
Bump travis ruby version to 2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 sudo: false
 
 rvm:
-  - 2.1.0
+  - 2.2.2
 
 notifications:
   irc:


### PR DESCRIPTION
The mustermann gem requires ruby version >= 2.2.0, which is currently
causing travis builds to fail. Bump the version so we can install all of
our gems.