### PR TITLE
align systemd dependency from crowbar-init to apache

### DIFF
--- a/config/crowbar-init.service
+++ b/config/crowbar-init.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Crowbar Init
 After=network.target syslog.target remote-fs.target
-Requires=apache2.service
+Wants=apache2.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
A change to the crowbar service file was made in crowbar-core:
https://github.com/crowbar/crowbar-core/pull/1317/commits/fbd1b480bd7a821844476bb8b9195458c27b0afb
It fixes a dependency issue.

This PR is to make the crowbar-init service file consistent with the
one from crowbar-core in terms of dependencies.