### PR TITLE
Increase logging output during chef-solo run

### DIFF
--- a/chef/solo.rb
+++ b/chef/solo.rb
@@ -21,7 +21,7 @@ root_path = File.expand_path("../..", __FILE__)
 # log_level specifies the level of verbosity for output.
 # valid values are: :debug, :info, :warn, :error, :fatal
 
-log_level :warn
+log_level :debug
 
 # log_location specifies where chef-solo should log to.
 # valid values are: a quoted string specifying a file, or STDOUT with


### PR DESCRIPTION
The current log level ("warn") has only minimal information about the
chef-solo run. Increasing the output ("debug") for
/var/log/chef/solo.log improves the situation.