### PR TITLE
 Fix handling of failing sanity checks (bsc#1016972)

### DIFF
--- a/lib/crowbar/init/helpers.rb
+++ b/lib/crowbar/init/helpers.rb
@@ -151,23 +151,27 @@ module Crowbar
         cmd_ret
       end
 
-      def crowbar_status(request_type = :html)
-        uri = if request_type == :html
-          URI.parse(installer_url)
+      def crowbar_request(url, request_type = :get, response_type = :html)
+        uri = URI.parse(url)
+
+        req = if request_type == :post
+          Net::HTTP::Post.new(
+            uri.request_uri
+          )
         else
-          URI.parse(status_url)
+          Net::HTTP::Get.new(
+            uri.request_uri
+          )
         end
 
         res = Net::HTTP.new(
           uri.host,
           uri.port
         ).request(
-          Net::HTTP::Get.new(
-            uri.request_uri
-          )
+          req
         )
 
-        body = if request_type == :html
+        body = if response_type == :html
           res.body
         else
           JSON.parse(res.body)
@@ -182,6 +186,12 @@ module Crowbar
           code: 500,
           body: nil
         }
+      end
+
+      def crowbar_status(response_type = :html)
+        crowbar_request(response_type == :html ? installer_url : status_url,
+                        :get,
+                        response_type)
       end
 
       # TODO: this method needs to be refactored a bit in general

--- a/lib/crowbar/init/helpers.rb
+++ b/lib/crowbar/init/helpers.rb
@@ -216,12 +216,12 @@ module Crowbar
           msg = "Timout while waiting for crowbar to become available"
           logger.error(msg)
           {
-            message: msg,
+            stdout_and_stderr: msg,
             exit_code: 2
           }
         rescue => e
           {
-            message: e.message.inspect,
+            stdout_and_stderr: e.message.inspect,
             exit_code: 1
           }
         end


### PR DESCRIPTION
When some pre-installation sanity checks failed, crowbar-init didn't detect this properly and timed out waiting for crowbar to come up.

Added explicit call to sanity checks API and reporting in case of any failures.